### PR TITLE
Added toggle on metadata and cluster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,9 +2152,9 @@
       }
     },
     "@tanem/svg-injector": {
-      "version": "8.0.57",
-      "resolved": "https://registry.npmjs.org/@tanem/svg-injector/-/svg-injector-8.0.57.tgz",
-      "integrity": "sha512-PUi7Rgtz+AV49mwwILHok2O7dT6Wd4K9w0x+HcE/clFCdtJLTEf1UJZfK0VvmiSkwvL//LFxpHT6xKrUJwwiww==",
+      "version": "8.0.58",
+      "resolved": "https://registry.npmjs.org/@tanem/svg-injector/-/svg-injector-8.0.58.tgz",
+      "integrity": "sha512-5UHH6YlTiJauycdiw2CO9L7hQL/7Abxxg4ybrZONbdl6LG+2VRrUYOwY3yeRFK0VQttDSUe14IP7GODRl82fRg==",
       "requires": {
         "@babel/runtime": "^7.10.4"
       }
@@ -12169,12 +12169,12 @@
       }
     },
     "react-svg": {
-      "version": "11.0.29",
-      "resolved": "https://registry.npmjs.org/react-svg/-/react-svg-11.0.29.tgz",
-      "integrity": "sha512-ak5E+uvz4pvOibgIhgW9wgygMBKfVErEwLKLj43o7+iC161nGYbmUeZ9aiS9W4/OoF+MWBEiNkNXpfNOI0SVRA==",
+      "version": "11.0.30",
+      "resolved": "https://registry.npmjs.org/react-svg/-/react-svg-11.0.30.tgz",
+      "integrity": "sha512-YxK78+wAhSNQXXdVnA1BXiN3XA6seNIs2x17PE1AY4zp4yM4ISJP2v6A9Qpis9nAjljb88ZXO2ZB5pQKuT6KuA==",
       "requires": {
         "@babel/runtime": "^7.10.4",
-        "@tanem/svg-injector": "^8.0.56",
+        "@tanem/svg-injector": "^8.0.57",
         "prop-types": "^15.7.2"
       }
     },

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -1,32 +1,22 @@
 import React, { useState } from "react";
 import { DragDropContext } from "react-beautiful-dnd";
 
-import { Column as DataColumn } from "data/classes";
-
 import { sourceColumn, columnsFromBackend } from "data/dummyData.js";
 import SearchList from "components/BoardWorkspace/SearchList/SearchList.js";
 import Column from "components/BoardWorkspace/Column/Column.js";
 import styles from "components/BoardWorkspace/BoardWorkspace.module.scss";
 import { Evidence } from "data/classes";
+import { Column as DataColumn } from "data/classes";
 import { uuid } from "uuidv4";
 
 // Updates states of all columns after a drag + place has occurred
 const updateColumnState = (result, columns, setColumns) => {
   if (!result.destination) {
-    console.log("make new cluster");
-    console.log(columns);
+    // make new column if not dropped on an existing column
     const destIndex = Object.entries(columns).length;
-    console.log(destIndex);
-    const newCol = new DataColumn("Destination " + destIndex);
-    console.log(newCol);
     const newId = uuid();
-    columns[newId] = newCol;
-    console.log(columns);
-    result.destination = {};
-    result.destination.droppableId = newId;
-    result.destination.index = 0;
-    console.log(result);
-    // return;
+    columns[newId] = new DataColumn("Destination " + destIndex);
+    result.destination = { droppableId: newId, index: 0 };
   }
   console.log(result);
   const { source, destination } = result;
@@ -77,6 +67,8 @@ const updateColumnState = (result, columns, setColumns) => {
       );
       sourceEvidence.mapped--;
     }
+    // TODO: check for empty columns and remove them
+
     setColumns({
       ...columns,
       [source.droppableId]: {

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -18,7 +18,6 @@ const updateColumnState = (result, columns, setColumns) => {
     columns[newId] = new DataColumn("Destination " + destIndex);
     result.destination = { droppableId: newId, index: 0 };
   }
-  console.log(result);
   const { source, destination } = result;
   if (source.droppableId !== destination.droppableId) {
     const sourceColumn = columns[source.droppableId];
@@ -133,6 +132,7 @@ const BoardWorkspace = (props) => {
                 />
               );
             }
+            return null;
           })}
         </div>
       </div>

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -109,14 +109,16 @@ const updateColumnState = (result, columns, setColumns) => {
   }
 };
 
-const BoardWorkspace = (props) => {
+const BoardWorkspace = (props) =>  {
   const modalCallback = props.modalCallback;
-  const [columns, setColumns] = useState({
-    ...sourceColumn,
-    ...columnsFromBackend,
-  });
+  const [showMetadata, setShowMetadata] = useState(true);
+  const [columns, setColumns] = useState({...sourceColumn, ...columnsFromBackend});
   const srcKey = Object.entries(sourceColumn)[0][0];
   const srcColState = columns[srcKey];
+
+  const handleShowMetadataClick = (e) => {
+    setShowMetadata(!e.target.checked);
+  }
 
   return (
     <DragDropContext
@@ -124,27 +126,30 @@ const BoardWorkspace = (props) => {
     >
       <div className={styles.boardWorkspace}>
         {/* SEARCH COLUMN */}
-        <SearchList
-          columnId={srcKey}
-          column={srcColState}
-          modalCallback={modalCallback}
-        />
+        <SearchList columnId = {srcKey} column = {srcColState} modalCallback={modalCallback} showMetadata={showMetadata}/>
+
 
         {/* DESTINATION BUCKETS */}
         <div className={styles.boardColumns}>
+          <div className={styles.switchContainer}>
+            <div className={styles.switchLabel}>
+              Hide Metadata
+            </div>
+            <input type="checkbox" id="toggle" className={styles.checkbox} onChange={(e) => handleShowMetadataClick(e)}/>  
+            <label htmlFor="toggle" className={styles.switch}></label>
+          </div>
           {Object.entries(columns).map(([columnId, column], index) => {
             if (columnId !== srcKey) {
-              return (
-                <Column
-                  columnId={columnId}
-                  column={column}
-                  key={columnId}
-                  searchQuery={null}
-                  tagFilter={null}
-                  showMapped={true}
-                  showUnmapped={true}
-                  modalCallback={modalCallback}
-                />
+              return (  <Column columnId={columnId}
+                                column = {column}
+                                key={columnId}
+                                searchQuery={null}
+                                tagFilter={null}
+                                showMapped={true}
+                                showUnmapped={true}
+                                modalCallback={modalCallback}
+                                showMetadata={showMetadata}
+                        />
               );
             }
             return null;

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -66,19 +66,11 @@ const updateColumnState = (result, columns, setColumns) => {
       );
       sourceEvidence.mapped--;
     }
-    // TODO: check for empty columns and remove them
-    console.log(columns);
     const colentries = Object.entries(columns);
     let deletesource = false;
     for (const [colid, colcontent] of colentries) {
       if (colcontent.name === sourceColumn.name) {
-        console.log(colid);
-        console.log(colcontent.items.length);
         if (colcontent.items.length <= 1) {
-          console.log("before");
-          console.log(columns);
-          console.log(colid);
-          console.log(columns[colid]);
           delete columns[colid];
           setColumns({
             ...columns,
@@ -87,9 +79,6 @@ const updateColumnState = (result, columns, setColumns) => {
               items: destItems,
             },
           });
-          // sourceColumn = null;
-          console.log("after");
-          console.log(columns);
         } else {
           setColumns({
             ...columns,

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -154,6 +154,11 @@ const BoardWorkspace = (props) =>  {
             }
             return null;
           })}
+          <div className={styles.emptyBucket}>
+            Drag an evidence here
+            <br/>
+            <div className={styles.emptyBucket__icon}>&#8853;</div>
+          </div>
         </div>
       </div>
     </DragDropContext>

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -15,7 +15,7 @@ const updateColumnState = (result, columns, setColumns) => {
     // make new column if not dropped on an existing column
     const destIndex = Object.entries(columns).length;
     const newId = uuid();
-    columns[newId] = new DataColumn("Destination " + destIndex);
+    columns[newId] = new DataColumn(newId);
     result.destination = { droppableId: newId, index: 0 };
   }
   const { source, destination } = result;
@@ -67,18 +67,44 @@ const updateColumnState = (result, columns, setColumns) => {
       sourceEvidence.mapped--;
     }
     // TODO: check for empty columns and remove them
-
-    setColumns({
-      ...columns,
-      [source.droppableId]: {
-        ...sourceColumn,
-        items: sourceItems,
-      },
-      [destination.droppableId]: {
-        ...destColumn,
-        items: destItems,
-      },
-    });
+    console.log(columns);
+    const colentries = Object.entries(columns);
+    let deletesource = false;
+    for (const [colid, colcontent] of colentries) {
+      if (colcontent.name === sourceColumn.name) {
+        console.log(colid);
+        console.log(colcontent.items.length);
+        if (colcontent.items.length <= 1) {
+          console.log("before");
+          console.log(columns);
+          console.log(colid);
+          console.log(columns[colid]);
+          delete columns[colid];
+          setColumns({
+            ...columns,
+            [destination.droppableId]: {
+              ...destColumn,
+              items: destItems,
+            },
+          });
+          // sourceColumn = null;
+          console.log("after");
+          console.log(columns);
+        } else {
+          setColumns({
+            ...columns,
+            [source.droppableId]: {
+              ...sourceColumn,
+              items: sourceItems,
+            },
+            [destination.droppableId]: {
+              ...destColumn,
+              items: destItems,
+            },
+          });
+        }
+      }
+    }
   } else {
     const column = columns[source.droppableId];
     const copiedItems = [...column.items];

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -88,12 +88,16 @@ const updateColumnState = (result, columns, setColumns) => {
   }
 };
 
-
 const BoardWorkspace = (props) =>  {
   const modalCallback = props.modalCallback;
+  const [showMetadata, setShowMetadata] = useState(true);
   const [columns, setColumns] = useState({...sourceColumn, ...columnsFromBackend});
   const srcKey = Object.entries(sourceColumn)[0][0];
   const srcColState = columns[srcKey];
+
+  const handleShowMetadataClick = (e) => {
+    setShowMetadata(!e.target.checked);
+  }
 
   return (
     <DragDropContext
@@ -101,11 +105,18 @@ const BoardWorkspace = (props) =>  {
     >
       <div className={styles.boardWorkspace}>
         {/* SEARCH COLUMN */}
-        <SearchList columnId = {srcKey} column = {srcColState} modalCallback={modalCallback}/>
+        <SearchList columnId = {srcKey} column = {srcColState} modalCallback={modalCallback} showMetadata={showMetadata}/>
 
 
         {/* DESTINATION BUCKETS */}
         <div className={styles.boardColumns}>
+          <div className={styles.switchContainer}>
+            <div className={styles.switchLabel}>
+              Hide Metadata
+            </div>
+            <input type="checkbox" id="toggle" className={styles.checkbox} onChange={(e) => handleShowMetadataClick(e)}/>  
+            <label htmlFor="toggle" className={styles.switch}></label>
+          </div>
           {Object.entries(columns).map(([columnId, column], index) => {
             if (columnId !== srcKey) {
 
@@ -117,6 +128,7 @@ const BoardWorkspace = (props) =>  {
                                 showMapped={true}
                                 showUnmapped={true}
                                 modalCallback={modalCallback}
+                                showMetadata={showMetadata}
                         />
               );
             }

--- a/src/components/BoardWorkspace/BoardWorkspace.js
+++ b/src/components/BoardWorkspace/BoardWorkspace.js
@@ -1,17 +1,34 @@
 import React, { useState } from "react";
 import { DragDropContext } from "react-beautiful-dnd";
 
-import { sourceColumn, columnsFromBackend } from 'data/dummyData.js';
-import SearchList from 'components/BoardWorkspace/SearchList/SearchList.js';
-import Column from 'components/BoardWorkspace/Column/Column.js';
-import styles from 'components/BoardWorkspace/BoardWorkspace.module.scss';
-import { Evidence } from "data/classes";
+import { Column as DataColumn } from "data/classes";
 
+import { sourceColumn, columnsFromBackend } from "data/dummyData.js";
+import SearchList from "components/BoardWorkspace/SearchList/SearchList.js";
+import Column from "components/BoardWorkspace/Column/Column.js";
+import styles from "components/BoardWorkspace/BoardWorkspace.module.scss";
+import { Evidence } from "data/classes";
+import { uuid } from "uuidv4";
 
 // Updates states of all columns after a drag + place has occurred
 const updateColumnState = (result, columns, setColumns) => {
-
-  if (!result.destination) return;
+  if (!result.destination) {
+    console.log("make new cluster");
+    console.log(columns);
+    const destIndex = Object.entries(columns).length;
+    console.log(destIndex);
+    const newCol = new DataColumn("Destination " + destIndex);
+    console.log(newCol);
+    const newId = uuid();
+    columns[newId] = newCol;
+    console.log(columns);
+    result.destination = {};
+    result.destination.droppableId = newId;
+    result.destination.index = 0;
+    console.log(result);
+    // return;
+  }
+  console.log(result);
   const { source, destination } = result;
   if (source.droppableId !== destination.droppableId) {
     const sourceColumn = columns[source.droppableId];
@@ -52,7 +69,6 @@ const updateColumnState = (result, columns, setColumns) => {
             (item) => item.quoteid === removed.quoteid
           );
           columns[srclistid].items[srcevid].mapped--;
-          console.log("the other one");
         }
       }
     } else {
@@ -60,7 +76,6 @@ const updateColumnState = (result, columns, setColumns) => {
         (item) => item.quoteid === removed.quoteid
       );
       sourceEvidence.mapped--;
-      console.log("this one");
     }
     setColumns({
       ...columns,
@@ -88,10 +103,12 @@ const updateColumnState = (result, columns, setColumns) => {
   }
 };
 
-
-const BoardWorkspace = (props) =>  {
+const BoardWorkspace = (props) => {
   const modalCallback = props.modalCallback;
-  const [columns, setColumns] = useState({...sourceColumn, ...columnsFromBackend});
+  const [columns, setColumns] = useState({
+    ...sourceColumn,
+    ...columnsFromBackend,
+  });
   const srcKey = Object.entries(sourceColumn)[0][0];
   const srcColState = columns[srcKey];
 
@@ -101,23 +118,27 @@ const BoardWorkspace = (props) =>  {
     >
       <div className={styles.boardWorkspace}>
         {/* SEARCH COLUMN */}
-        <SearchList columnId = {srcKey} column = {srcColState} modalCallback={modalCallback}/>
-
+        <SearchList
+          columnId={srcKey}
+          column={srcColState}
+          modalCallback={modalCallback}
+        />
 
         {/* DESTINATION BUCKETS */}
         <div className={styles.boardColumns}>
           {Object.entries(columns).map(([columnId, column], index) => {
             if (columnId !== srcKey) {
-
-              return (  <Column columnId={columnId}
-                                column = {column}
-                                key={columnId}
-                                searchQuery={null}
-                                tagFilter={null}
-                                showMapped={true}
-                                showUnmapped={true}
-                                modalCallback={modalCallback}
-                        />
+              return (
+                <Column
+                  columnId={columnId}
+                  column={column}
+                  key={columnId}
+                  searchQuery={null}
+                  tagFilter={null}
+                  showMapped={true}
+                  showUnmapped={true}
+                  modalCallback={modalCallback}
+                />
               );
             }
           })}

--- a/src/components/BoardWorkspace/BoardWorkspace.module.scss
+++ b/src/components/BoardWorkspace/BoardWorkspace.module.scss
@@ -5,14 +5,67 @@
   display: flex; 
   flex-direction: row;
   height: 90vh;
+  background-color: $grey-1;
 }
 
 .boardColumns {
   display: flex; 
   flex-direction: row;
   max-height: 100%;
-  overflow-y: auto;
-  background-color: $grey-1;
+  overflow: auto;
   width: 100%;
-  //overflow-x: hidden; //Disable later when have more columns
+
+  > :not(:first-child) {
+    margin-top: 3rem;
+  }
+}
+
+.switchContainer {
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 0;
+  margin-top: 1rem;
+  margin-right: 1rem;
+}
+
+.switchLabel {
+  font-size: 0.8rem;
+  margin-right: 1rem;
+  margin-top: 0.2rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  background-color: rgba(0, 0, 0, 0.25);
+  border-radius: 20px;
+  transition: all 0.3s;
+  &:hover {
+    cursor:pointer;
+  }
+}
+
+.switch::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius:50%;
+  background-color: white;
+  top: 1px;
+  left: 1px;
+  transition: all 0.3s;
+}
+
+.checkbox:checked + .switch::after {
+  left : 20px;
+}
+.checkbox:checked + .switch {
+  background-color: $grey-8;
+}
+.checkbox {
+  display : none;
 }

--- a/src/components/BoardWorkspace/BoardWorkspace.module.scss
+++ b/src/components/BoardWorkspace/BoardWorkspace.module.scss
@@ -2,17 +2,17 @@
 @import "styles/partials/_padding.scss";
 
 .boardWorkspace {
-  display: flex; 
+  display: flex;
   flex-direction: row;
   height: 90vh;
+  background-color: $offwhite;
 }
 
 .boardColumns {
-  display: flex; 
+  display: flex;
   flex-direction: row;
   max-height: 100%;
   overflow-y: auto;
-  background-color: $grey-1;
-  width: 100%;
-  //overflow-x: hidden; //Disable later when have more columns
+  overflow-x: auto;
+  background-color: $offwhite;
 }

--- a/src/components/BoardWorkspace/BoardWorkspace.module.scss
+++ b/src/components/BoardWorkspace/BoardWorkspace.module.scss
@@ -5,14 +5,67 @@
   display: flex;
   flex-direction: row;
   height: 90vh;
-  background-color: $offwhite;
+  background-color: $grey-1;
 }
 
 .boardColumns {
   display: flex;
   flex-direction: row;
   max-height: 100%;
-  overflow-y: auto;
-  overflow-x: auto;
-  background-color: $offwhite;
+  overflow: auto;
+  width: 100%;
+
+  > :not(:first-child) {
+    margin-top: 3rem;
+  }
+}
+
+.switchContainer {
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  right: 0;
+  margin-top: 1rem;
+  margin-right: 1rem;
+}
+
+.switchLabel {
+  font-size: 0.8rem;
+  margin-right: 1rem;
+  margin-top: 0.2rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  background-color: rgba(0, 0, 0, 0.25);
+  border-radius: 20px;
+  transition: all 0.3s;
+  &:hover {
+    cursor:pointer;
+  }
+}
+
+.switch::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius:50%;
+  background-color: white;
+  top: 1px;
+  left: 1px;
+  transition: all 0.3s;
+}
+
+.checkbox:checked + .switch::after {
+  left : 20px;
+}
+.checkbox:checked + .switch {
+  background-color: $grey-8;
+}
+.checkbox {
+  display : none;
 }

--- a/src/components/BoardWorkspace/BoardWorkspace.module.scss
+++ b/src/components/BoardWorkspace/BoardWorkspace.module.scss
@@ -20,6 +20,29 @@
   }
 }
 
+.emptyBucket {
+  min-width: 25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 10rem;
+  border-radius: 10px;
+  color: $grey-4;
+  transition: all .2s ease-in;
+  margin-left: 1rem;
+  font-weight: bold;
+
+  &:hover {
+    color: $grey-8;
+    background-color: white;
+  }
+
+  &__icon {
+    font-size: 2rem;
+  }
+}
+
 .switchContainer {
   display: flex;
   flex-direction: row;

--- a/src/components/BoardWorkspace/Column/Column.js
+++ b/src/components/BoardWorkspace/Column/Column.js
@@ -7,8 +7,9 @@ import { tags } from 'data/dummyData.js';
 
 const Column = (props) => {
   const [starred, toggleStar] = useState(false);
+  const [showCards, setShowCards] = useState(true);
 
-  let {column, columnId, searchQuery, tagFilter, showMapped, showUnmapped, modalCallback} = props;
+  let {column, columnId, searchQuery, tagFilter, showMapped, showUnmapped, modalCallback, showMetadata} = props;
   let srcId = Object.keys(sourceColumn)[0];
 
   const renderEvidence = () => {
@@ -31,7 +32,9 @@ const Column = (props) => {
     }
 
     return (list.map((item, index) => {
-      return <Evidence item={item} index={index} key={index} modalCallback={modalCallback}/> 
+      return <div className={styles.evidenceContainer} key={index}>
+                <Evidence item={item} index={index} modalCallback={modalCallback} showMetadata={showMetadata}/> 
+              </div>
     }));
 
   };
@@ -48,6 +51,11 @@ const Column = (props) => {
                     onClick={() => handleStarClick()}
                     style={{ color: starred ? "#FF6635" : "#CED4DA"}}>
                     &#9733;
+              </div>
+              <div className={styles.toggleArrow}
+                   onClick={() => setShowCards(!showCards)}
+                   style={{transform: showCards ? "rotate(180deg)" : "rotate(0deg)"}}>
+                &#9650;
               </div>
             </div>);
   }
@@ -71,7 +79,7 @@ const Column = (props) => {
                 {column.items.length > 1 && columnId !== srcId && renderClusterHeader()}
 
                 {/* EVIDENCE LIST */}
-                {renderEvidence()}
+                {showCards && renderEvidence()}
                 {provided.placeholder}
               </div>
             );

--- a/src/components/BoardWorkspace/Column/Column.js
+++ b/src/components/BoardWorkspace/Column/Column.js
@@ -1,83 +1,116 @@
 import React, { useState } from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
-import Evidence from 'components/BoardWorkspace/Evidence/Evidence.js';
-import styles from 'components/BoardWorkspace/Column/Column.module.scss';
-import { sourceColumn } from 'data/dummyData.js';
-import { tags } from 'data/dummyData.js';
+import Evidence from "components/BoardWorkspace/Evidence/Evidence.js";
+import styles from "components/BoardWorkspace/Column/Column.module.scss";
+import { sourceColumn } from "data/dummyData.js";
+import { tags } from "data/dummyData.js";
 
 const Column = (props) => {
   const [starred, toggleStar] = useState(false);
 
-  let {column, columnId, searchQuery, tagFilter, showMapped, showUnmapped, modalCallback} = props;
+  let {
+    column,
+    columnId,
+    searchQuery,
+    tagFilter,
+    showMapped,
+    showUnmapped,
+    modalCallback,
+  } = props;
   let srcId = Object.keys(sourceColumn)[0];
 
   const renderEvidence = () => {
     let list = column.items;
 
     if (searchQuery !== "" && searchQuery !== null) {
-      list = list.filter(evidence => evidence.quote.toLowerCase().includes(searchQuery.toLowerCase()));
+      list = list.filter((evidence) =>
+        evidence.quote.toLowerCase().includes(searchQuery.toLowerCase())
+      );
     }
 
     if (tagFilter !== null) {
-      list = list.filter(evidence => evidence.hasTag(tags[tagFilter]));
+      list = list.filter((evidence) => evidence.hasTag(tags[tagFilter]));
     }
 
     if (!showMapped) {
-      list = list.filter(evidence => evidence.mapped === 0);
+      list = list.filter((evidence) => evidence.mapped === 0);
     }
 
     if (!showUnmapped) {
-      list = list.filter(evidence => evidence.mapped > 0);
+      list = list.filter((evidence) => evidence.mapped > 0);
     }
 
-    return (list.map((item, index) => {
-      return <Evidence item={item} index={index} key={index} modalCallback={modalCallback}/> 
-    }));
-
+    return list.map((item, index) => {
+      return (
+        <Evidence
+          item={item}
+          index={index}
+          key={index}
+          modalCallback={modalCallback}
+        />
+      );
+    });
   };
 
   const handleStarClick = () => {
     toggleStar(!starred);
     column.toggleStar();
-  }
+  };
 
   const renderClusterHeader = () => {
-    return (<div className={styles.columnTitle}> 
-              <input placeholder="Enter cluster name"></input>
-              <div className={styles.columnStar} 
-                    onClick={() => handleStarClick()}
-                    style={{ color: starred ? "#FF6635" : "#CED4DA"}}>
-                    &#9733;
-              </div>
-            </div>);
-  }
+    return (
+      <div className={styles.columnTitle}>
+        <input placeholder="Enter cluster name"></input>
+        <div
+          className={styles.columnStar}
+          onClick={() => handleStarClick()}
+          style={{ color: starred ? "#FF6635" : "#CED4DA" }}
+        >
+          &#9733;
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div
-      className={columnId === srcId ? styles.sourceColumnContainer : styles.columnContainer}
+      className={
+        columnId === srcId
+          ? styles.sourceColumnContainer
+          : styles.columnContainer
+      }
       key={columnId}
     >
-        <Droppable droppableId={columnId} key={columnId}>
-          {(provided, snapshot) => {
-            return (
-              <div
-                {...provided.droppableProps}
-                ref={provided.innerRef}
-                className = {columnId === srcId ? styles.sourceColumn : styles.column}
-                style={{ background: snapshot.isDraggingOver? "#D3E9FF" : "white"}}
-              >
+      <Droppable droppableId={columnId} key={columnId}>
+        {(provided, snapshot) => {
+          return (
+            <div
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              className={
+                columnId === srcId ? styles.sourceColumn : styles.column
+              }
+              style={{
+                background: snapshot.isDraggingOver
+                  ? "#D3E9FF"
+                  : column.items.length > 1
+                  ? "white"
+                  : "#FFFFFF00",
+              }}
+            >
+              {/* COLUMN TITLE */}
+              {column.items.length > 1 &&
+                columnId !== srcId &&
+                renderClusterHeader()}
 
-                {/* COLUMN TITLE */}
-                {column.items.length > 1 && columnId !== srcId && renderClusterHeader()}
-
-                {/* EVIDENCE LIST */}
-                {renderEvidence()}
-                {provided.placeholder}
-              </div>
-            );
-          }}
-        </Droppable>
-      </div>
+              {/* EVIDENCE LIST */}
+              {renderEvidence()}
+              {provided.placeholder}
+            </div>
+          );
+        }}
+      </Droppable>
+    </div>
   );
 };
 

--- a/src/components/BoardWorkspace/Column/Column.js
+++ b/src/components/BoardWorkspace/Column/Column.js
@@ -9,19 +9,7 @@ const Column = (props) => {
   const [starred, toggleStar] = useState(false);
   const [showCards, setShowCards] = useState(true);
 
-<<<<<<< HEAD
-  let {
-    column,
-    columnId,
-    searchQuery,
-    tagFilter,
-    showMapped,
-    showUnmapped,
-    modalCallback,
-  } = props;
-=======
   let {column, columnId, searchQuery, tagFilter, showMapped, showUnmapped, modalCallback, showMetadata} = props;
->>>>>>> Toggle on metadata and cluster.
   let srcId = Object.keys(sourceColumn)[0];
 
   const renderEvidence = () => {

--- a/src/components/BoardWorkspace/Column/Column.js
+++ b/src/components/BoardWorkspace/Column/Column.js
@@ -7,7 +7,9 @@ import { tags } from "data/dummyData.js";
 
 const Column = (props) => {
   const [starred, toggleStar] = useState(false);
+  const [showCards, setShowCards] = useState(true);
 
+<<<<<<< HEAD
   let {
     column,
     columnId,
@@ -17,6 +19,9 @@ const Column = (props) => {
     showUnmapped,
     modalCallback,
   } = props;
+=======
+  let {column, columnId, searchQuery, tagFilter, showMapped, showUnmapped, modalCallback, showMetadata} = props;
+>>>>>>> Toggle on metadata and cluster.
   let srcId = Object.keys(sourceColumn)[0];
 
   const renderEvidence = () => {
@@ -40,16 +45,12 @@ const Column = (props) => {
       list = list.filter((evidence) => evidence.mapped > 0);
     }
 
-    return list.map((item, index) => {
-      return (
-        <Evidence
-          item={item}
-          index={index}
-          key={index}
-          modalCallback={modalCallback}
-        />
-      );
-    });
+    return (list.map((item, index) => {
+      return <div className={styles.evidenceContainer} key={index}>
+                <Evidence item={item} index={index} modalCallback={modalCallback} showMetadata={showMetadata}/> 
+              </div>
+    }));
+
   };
 
   const handleStarClick = () => {
@@ -58,19 +59,20 @@ const Column = (props) => {
   };
 
   const renderClusterHeader = () => {
-    return (
-      <div className={styles.columnTitle}>
-        <input placeholder="Enter cluster name"></input>
-        <div
-          className={styles.columnStar}
-          onClick={() => handleStarClick()}
-          style={{ color: starred ? "#FF6635" : "#CED4DA" }}
-        >
-          &#9733;
-        </div>
-      </div>
-    );
-  };
+    return (<div className={styles.columnTitle}> 
+              <input placeholder="Enter cluster name"></input>
+              <div className={styles.columnStar} 
+                    onClick={() => handleStarClick()}
+                    style={{ color: starred ? "#FF6635" : "#CED4DA"}}>
+                    &#9733;
+              </div>
+              <div className={styles.toggleArrow}
+                   onClick={() => setShowCards(!showCards)}
+                   style={{transform: showCards ? "rotate(180deg)" : "rotate(0deg)"}}>
+                &#9650;
+              </div>
+            </div>);
+  }
 
   return (
     <div
@@ -98,19 +100,19 @@ const Column = (props) => {
                   : "#FFFFFF00",
               }}
             >
+              
               {/* COLUMN TITLE */}
-              {column.items.length > 1 &&
-                columnId !== srcId &&
-                renderClusterHeader()}
+              {column.items.length > 1 && columnId !== srcId &&renderClusterHeader()}
 
               {/* EVIDENCE LIST */}
-              {renderEvidence()}
+              {showCards && renderEvidence()}
               {provided.placeholder}
+
             </div>
-          );
-        }}
-      </Droppable>
-    </div>
+            );
+          }}
+        </Droppable>
+      </div>
   );
 };
 

--- a/src/components/BoardWorkspace/Column/Column.module.scss
+++ b/src/components/BoardWorkspace/Column/Column.module.scss
@@ -5,15 +5,14 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
   overflow-y: auto;
-  min-width: 200px;
+  min-width: 25rem;
   padding: 0.5rem;
 }
 
 .column {
   box-sizing: border-box;
-  width: 100%;
+  min-width: 100%;
   padding: 1rem;
   background-color: white;
   border-radius: 10px;

--- a/src/components/BoardWorkspace/Column/Column.module.scss
+++ b/src/components/BoardWorkspace/Column/Column.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   width: 100%;
   overflow-y: auto;
-  min-width: 200px;
+  min-width: 300px;
   padding: 0.5rem;
 }
 
@@ -38,14 +38,14 @@
 
 .columnTitle {
   padding: 0.2rem;
-  margin-bottom: 1rem;
   display: flex;
   flex-direction: row;
+  align-items: center;
 
   > input {
+    flex-grow: 1;
     font-size: 0.8rem;
     box-sizing: border-box;
-    flex-grow: 1;
     border: 0;
     padding: 0.5rem 0.5rem;
 
@@ -56,10 +56,28 @@
 }
 
 .columnStar {
+  margin-left: 0.5rem;
   color: $grey-4;
-
+  user-select: none;
   &:hover {
     color: $salmon-1;
     cursor: pointer;
+  }
+}
+
+.toggleArrow {
+  margin-left: 0.5rem;
+  user-select: none;
+  transition: .1s ease-in-out;
+  font-size: 0.8rem;
+  &:hover {
+    color: $salmon-1;
+    cursor: pointer;
+  }
+}
+
+.evidenceContainer {
+  & > * {
+    margin-top: 1rem;
   }
 }

--- a/src/components/BoardWorkspace/Column/Column.module.scss
+++ b/src/components/BoardWorkspace/Column/Column.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   overflow-y: auto;
   min-width: 25rem;
-  padding: 0.5rem;
+  margin: 0.5rem;
 }
 
 .column {

--- a/src/components/BoardWorkspace/Column/Column.module.scss
+++ b/src/components/BoardWorkspace/Column/Column.module.scss
@@ -7,6 +7,7 @@
   align-items: center;
   overflow-y: auto;
   min-width: 25rem;
+  min-width: 300px;
   padding: 0.5rem;
 }
 
@@ -37,14 +38,14 @@
 
 .columnTitle {
   padding: 0.2rem;
-  margin-bottom: 1rem;
   display: flex;
   flex-direction: row;
+  align-items: center;
 
   > input {
+    flex-grow: 1;
     font-size: 0.8rem;
     box-sizing: border-box;
-    flex-grow: 1;
     border: 0;
     padding: 0.5rem 0.5rem;
 
@@ -55,10 +56,28 @@
 }
 
 .columnStar {
+  margin-left: 0.5rem;
   color: $grey-4;
-
+  user-select: none;
   &:hover {
     color: $salmon-1;
     cursor: pointer;
+  }
+}
+
+.toggleArrow {
+  margin-left: 0.5rem;
+  user-select: none;
+  transition: .1s ease-in-out;
+  font-size: 0.8rem;
+  &:hover {
+    color: $salmon-1;
+    cursor: pointer;
+  }
+}
+
+.evidenceContainer {
+  & > * {
+    margin-top: 1rem;
   }
 }

--- a/src/components/BoardWorkspace/Evidence/Evidence.js
+++ b/src/components/BoardWorkspace/Evidence/Evidence.js
@@ -3,7 +3,40 @@ import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import styles from "components/BoardWorkspace/Evidence/Evidence.module.scss";
 
 const Evidence = (props) => {
-  let {item, index, modalCallback} = props;
+  let {item, index, modalCallback, showMetadata} = props;
+
+  const renderMetadataCard = () => {
+    return (
+      <div>
+        <div className={styles.evidence__header}>
+          <div className={styles.evidence__title}>{item.participant.id + " - " + item.participant.occupation}</div>
+          <div className={styles.evidence__info} onClick={() => modalCallback(item)}>&#9776;</div>
+          <div className={styles.evidence__icon}><div>{item.createdBy.initials}</div></div>
+        </div>
+        <div className={styles.evidence__quote}>{item.quote}</div>
+        <br/>
+
+        {/* TAGS */}
+        <div className={styles.tagsContainer}>
+          {item.tags.map((tag, index) => {
+            return (
+              <div
+                className={styles.tag}
+                key={tag.id}
+                style={{ background: tag.color }}
+              >
+                {tag.name}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  const renderSimpleCard = () => {
+    return (<div className={styles.evidence__quote}>{item.quote}</div>)
+  }
 
   return (
     <Draggable key={item.id} draggableId={item.id} index={index}>
@@ -21,28 +54,8 @@ const Evidence = (props) => {
               ...provided.draggableProps.style
             }}
           >
-            <div className={styles.evidence__header}>
-              <div className={styles.evidence__title}>{item.participant.id + " - " + item.participant.occupation}</div>
-              <div className={styles.evidence__info} onClick={() => modalCallback(item)}>&#9776;</div>
-              <div className={styles.evidence__icon}><div>{item.createdBy.initials}</div></div>
-            </div>
-            <div className={styles.evidence__quote}>{item.quote}</div>
-            <br>
-            </br>
-            {/* TAGS */}
-            <div className={styles.tagsContainer}>
-              {item.tags.map((tag, index) => {
-                return (
-                  <div
-                    className={styles.tag}
-                    key={tag.id}
-                    style={{ background: tag.color }}
-                  >
-                    {tag.name}
-                  </div>
-                );
-              })}
-            </div>
+            {showMetadata && renderMetadataCard()}
+            {!showMetadata && renderSimpleCard()}
           </div>
         );
       }}

--- a/src/components/BoardWorkspace/Evidence/Evidence.js
+++ b/src/components/BoardWorkspace/Evidence/Evidence.js
@@ -50,7 +50,7 @@ const Evidence = (props) => {
             style={{
               opacity: item.mapped > 0 ? "40%" : "100%",
               backgroundColor: snapshot.isDragging? "#a6c4e3" : "#F1F3F5",
-              border: snapshot.isDragging? "3px solid #FF6635" : "none",
+              border: snapshot.isDragging? "3px solid #FF6635" : "3px solid white",
               ...provided.draggableProps.style
             }}
           >

--- a/src/components/BoardWorkspace/Evidence/Evidence.module.scss
+++ b/src/components/BoardWorkspace/Evidence/Evidence.module.scss
@@ -4,7 +4,6 @@
 .evidence {
   user-select: "none";
   padding: 1rem;
-  margin: 0 0 1rem 0;
   border-radius: 10px;
 
   > div {
@@ -38,7 +37,7 @@
   }
 
   &__quote {
-    font-size: 1rem;
+    font-size: 0.8rem;
   }
 
   &__info {

--- a/src/components/BoardWorkspace/SearchList/SearchList.js
+++ b/src/components/BoardWorkspace/SearchList/SearchList.js
@@ -4,7 +4,7 @@ import styles from 'components/BoardWorkspace/SearchList/SearchList.module.scss'
 import { tags } from 'data/dummyData.js';
 
 const SearchList = (props) =>  {
-  const {column, columnId, modalCallback} = props;
+  const {column, columnId, modalCallback, showMetadata} = props;
   const [searchQuery, setSearchQuery] = useState(null);
   const [tagFilter, setTagFilter] = useState(null);
   const [showMapped, setMapped] = useState(true);
@@ -75,6 +75,7 @@ const SearchList = (props) =>  {
                 showMapped = {showMapped}
                 showUnmapped = {showUnmapped}
                 modalCallback={modalCallback}
+                showMetadata={showMetadata}
         />
       </div>
   );

--- a/src/components/BoardWorkspace/SearchList/SearchList.module.scss
+++ b/src/components/BoardWorkspace/SearchList/SearchList.module.scss
@@ -4,7 +4,7 @@
 
 .searchList {
   box-sizing: border-box;
-  width: 30%;
+  min-width: 25rem;
   background-color: white;
   border-right: 1px solid $grey-4;
   border-top: 1px solid $grey-4;
@@ -68,7 +68,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  font-size: 0.8rem; 
+  font-size: 0.8rem;
   align-items: center;
 
   > label {

--- a/src/components/BoardWorkspace/SearchList/SearchList.module.scss
+++ b/src/components/BoardWorkspace/SearchList/SearchList.module.scss
@@ -64,7 +64,6 @@
 }
 
 .checkboxes {
-  margin-bottom: 1rem;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -102,7 +102,7 @@ const Modal = (props) =>  {
                 </div>
                   {evidence.commentThread && evidence.commentThread.map((comment, index) => {
                     return (
-                      <Comment member={comment.member} text={comment.text} date={comment.date}/>
+                      <Comment key={index} member={comment.member} text={comment.text} date={comment.date}/>
                     )
                   })}
               </div>

--- a/src/data/dummyData.js
+++ b/src/data/dummyData.js
@@ -60,4 +60,6 @@ export const columnsFromBackend = {
   [uuid()]: new Column("Destination 2"),
   [uuid()]: new Column("Destination 3"),
   [uuid()]: new Column("Destination 4"),
+  [uuid()]: new Column("Destination 5"),
+  [uuid()]: new Column("Destination 6"),
 };

--- a/src/data/dummyData.js
+++ b/src/data/dummyData.js
@@ -1,6 +1,13 @@
 import uuid from "uuid/v4";
-import moment from 'moment';
-import { Evidence, Column, Tag, Member, Participant, Comment } from "data/classes.js";
+import moment from "moment";
+import {
+  Evidence,
+  Column,
+  Tag,
+  Member,
+  Participant,
+  Comment,
+} from "data/classes.js";
 
 // Members
 export const members = {
@@ -13,10 +20,25 @@ export const members = {
 
 // Participants
 export const participants = {
-  P1: new Participant("P1", "Staff Engineer", "500", "Been at company for 2 years."),
-  P2: new Participant("P2", "Project Manager", "1000", "Recently moved to this company."),
-  P3: new Participant("P3", "Senior Designer", "750", "Have been working in company for 10 years.")
-}
+  P1: new Participant(
+    "P1",
+    "Staff Engineer",
+    "500",
+    "Been at company for 2 years."
+  ),
+  P2: new Participant(
+    "P2",
+    "Project Manager",
+    "1000",
+    "Recently moved to this company."
+  ),
+  P3: new Participant(
+    "P3",
+    "Senior Designer",
+    "750",
+    "Have been working in company for 10 years."
+  ),
+};
 
 // Tags
 export const tags = {
@@ -29,25 +51,103 @@ export const tags = {
 
 // Comment threads
 const commentThreads = {
-  ONE: [new Comment(members.MATT, "How much lorem can we ipsum?", moment().day(-1)),
-        new Comment(members.MARGOT, "How much ipsum can we lorem?", moment().day(0)),
-        new Comment(members.MICHAEL, "Why does lorem need an ipsum?", moment().day(0))]
-}
+  ONE: [
+    new Comment(members.MATT, "How much lorem can we ipsum?", moment().day(-1)),
+    new Comment(
+      members.MARGOT,
+      "How much ipsum can we lorem?",
+      moment().day(0)
+    ),
+    new Comment(
+      members.MICHAEL,
+      "Why does lorem need an ipsum?",
+      moment().day(0)
+    ),
+  ],
+};
 
 // Evidence
 const items = [
-  new Evidence("Quote1 here", [tags.YAKITORI, tags.SOBA],  members.MATT,    participants.P1, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote2 here", [tags.YAKITORI, tags.SUSHI], members.MARGOT,  participants.P2, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote3 here", [tags.TEMPURA],              members.CAITLIN, participants.P3, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote4 here", [tags.TEMPURA, tags.SUSHI],  members.HALEY,   participants.P1, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote5 here", [tags.TEMPURA, tags.RAMEN],  members.MICHAEL, participants.P2, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote6 here", [tags.YAKITORI, tags.SOBA],  members.MATT,    participants.P3, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote7 here", [tags.YAKITORI, tags.SUSHI], members.MARGOT,  participants.P1, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote8 here", [tags.TEMPURA],              members.CAITLIN, participants.P2, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote9 here", [tags.TEMPURA, tags.SUSHI],  members.HALEY,   participants.P3, {start: "I am the beginning", end: "I am the end."}, commentThreads.ONE),
-  new Evidence("Quote10 here",[tags.TEMPURA, tags.RAMEN],  members.MICHAEL, participants.P1, {start: "I am the beginning", end: "I am the end."}),
+  new Evidence(
+    "Quote1 here",
+    [tags.YAKITORI, tags.SOBA],
+    members.MATT,
+    participants.P1,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote2 here",
+    [tags.YAKITORI, tags.SUSHI],
+    members.MARGOT,
+    participants.P2,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote3 here",
+    [tags.TEMPURA],
+    members.CAITLIN,
+    participants.P3,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote4 here",
+    [tags.TEMPURA, tags.SUSHI],
+    members.HALEY,
+    participants.P1,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote5 here",
+    [tags.TEMPURA, tags.RAMEN],
+    members.MICHAEL,
+    participants.P2,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote6 here",
+    [tags.YAKITORI, tags.SOBA],
+    members.MATT,
+    participants.P3,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote7 here",
+    [tags.YAKITORI, tags.SUSHI],
+    members.MARGOT,
+    participants.P1,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote8 here",
+    [tags.TEMPURA],
+    members.CAITLIN,
+    participants.P2,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote9 here",
+    [tags.TEMPURA, tags.SUSHI],
+    members.HALEY,
+    participants.P3,
+    { start: "I am the beginning", end: "I am the end." },
+    commentThreads.ONE
+  ),
+  new Evidence(
+    "Quote10 here",
+    [tags.TEMPURA, tags.RAMEN],
+    members.MICHAEL,
+    participants.P1,
+    { start: "I am the beginning", end: "I am the end." }
+  ),
 ];
-
 
 // Source list / bucket
 export const sourceColumn = {
@@ -55,9 +155,10 @@ export const sourceColumn = {
 };
 
 // Empty destination buckets
-export const columnsFromBackend = {
-  [uuid()]: new Column("Destination 1"),
-  [uuid()]: new Column("Destination 2"),
-  [uuid()]: new Column("Destination 3"),
-  [uuid()]: new Column("Destination 4"),
-};
+export const columnsFromBackend = {};
+// export const columnsFromBackend = {
+//   [uuid()]: new Column("Destination 1"),
+//   [uuid()]: new Column("Destination 2"),
+//   [uuid()]: new Column("Destination 3"),
+//   [uuid()]: new Column("Destination 4"),
+// };

--- a/src/styles/partials/_colors.scss
+++ b/src/styles/partials/_colors.scss
@@ -8,3 +8,4 @@ $grey-1: #F1F3F5;
 $grey-4: #CED4DA;
 $grey-6: #868E96;
 $grey-7: #495057;
+$grey-8: #343A40;

--- a/src/styles/partials/_colors.scss
+++ b/src/styles/partials/_colors.scss
@@ -8,5 +8,6 @@ $grey-1: #f1f3f5;
 $grey-4: #ced4da;
 $grey-6: #868e96;
 $grey-7: #495057;
+$grey-8: #343A40;
 
 $offwhite: #fafafa;

--- a/src/styles/partials/_colors.scss
+++ b/src/styles/partials/_colors.scss
@@ -1,10 +1,12 @@
-$salmon-1: #FF6635;
+$salmon-1: #ff6635;
 
-$sea-1: #29509D;
-$sea-2: #768FC0;
+$sea-1: #29509d;
+$sea-2: #768fc0;
 
-$grey-0: #F8F9FA;
-$grey-1: #F1F3F5;
-$grey-4: #CED4DA;
-$grey-6: #868E96;
+$grey-0: #f8f9fa;
+$grey-1: #f1f3f5;
+$grey-4: #ced4da;
+$grey-6: #868e96;
 $grey-7: #495057;
+
+$offwhite: #fafafa;


### PR DESCRIPTION
For https://github.com/coyiutoc/Honda-Capstone-Salmon/issues/12 "Hide Metadata" MoSCoW feature + added toggle on cluster content visibility.

- Added master switch anchored at top right of workspace area, so will remain visible in FOV even if scrolled.
  - Toggles the all cards to show only the quote, or the standard quote + metadata version.
- Added the arrow triangle onto clusters which hide/show cards.